### PR TITLE
Multilingual OCR/TTS + Azure OpenAI LLM-OCR fallback, prod fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -190,7 +190,9 @@ MESSAGES = {
         "limits_status": "📊 Лимиты\n\nБесплатно сегодня: {free_left}/{free_total}\nБонусные запросы: {bonus_left}\nБонус действует до: {bonus_until}",
         "limit_reached": "⚠️ На сегодня бесплатный лимит исчерпан и бонусные запросы закончились. Возвращайтесь завтра или поддержите проект для дополнительных запросов.",
         "mission_intro": "☕ Финансирование доступности\n\nYonchee создан, чтобы помогать людям, которым сложно читать. Название связано с Иваном (Yonchee): в юности у него значительно ухудшилось зрение, и это стало отправной точкой идеи продукта.",
-        "mission_short_audio": "Yonchee помогает людям, которым сложно читать, превращая фото и PDF в голосовые сообщения внутри Telegram.",
+        # Audio-only (never displayed): Latin tokens are spelled phonetically so the
+        # Russian neural voice doesn't mangle them (PDF -> "пи-ди-эф", brand -> "Йончи").
+        "mission_short_audio": "Йончи помогает людям, которым сложно читать, превращая фото и пи-ди-эф в голосовые сообщения внутри Телеграма.",
         "onboarding_start_button": "🚀 Начать",
         "onboarding_listen_button": "🔊 Прослушать миссию",
         "onboarding_support_button": "💙 Поддержать проект (донат)",

--- a/app.py
+++ b/app.py
@@ -1559,6 +1559,22 @@ def extract_text(file_path: str, file_type: str, pinned_lang: str = None) -> Ocr
                      script_lang, False, segments)
 
 
+async def _safe_edit_text(message, text, **kwargs):
+    """Edit a status message without letting a Telegram edit failure abort the
+    flow. A cold-start update redelivery can leave a just-sent status message
+    momentarily non-editable ("Message can't be edited") — but a failed cosmetic
+    status update must never stop us from delivering the OCR audio. Falls back to
+    a fresh message so any attached keyboard/menu still reaches the user."""
+    try:
+        await message.edit_text(text, **kwargs)
+    except Exception as ex:
+        logger.warning(f"status edit_text failed, sending fresh message: {ex!r}")
+        try:
+            await message.chat.send_message(text, **kwargs)
+        except Exception as ex2:
+            logger.warning(f"status fallback send_message failed: {ex2!r}")
+
+
 async def _process_file_payload(
         update: Update,
         context: ContextTypes.DEFAULT_TYPE,
@@ -1591,7 +1607,7 @@ async def _process_file_payload(
             normalized_text = ocr.text
             ocr_ms = round((time.monotonic() - t0) * 1000)
             if not normalized_text.strip():
-                await status_message.edit_text(t(update, "no_text"))
+                await _safe_edit_text(status_message,t(update, "no_text"))
                 await context.bot.send_message(chat_id, t(update, "help"))
                 log_usage(user_id, status="failure", reason="no_text_fallback",
                           file_type=file_type, file_size_kb=file_size_kb, duration_ms=ocr_ms,
@@ -1602,7 +1618,7 @@ async def _process_file_payload(
                 "file_type": file_type, "file_size_kb": file_size_kb, "cost_credits": cost_credits,
             }
             info = VOICE_MAP[default_lang]
-            await status_message.edit_text(
+            await _safe_edit_text(status_message,
                 t(update, "using_default").format(lang=f'{info["flag"]} {info["name"]}')
             )
             stop_typing.set()
@@ -1617,7 +1633,7 @@ async def _process_file_payload(
 
         if not normalized_text.strip():
             logger.info(f"User {user_id} uploaded a file with no detectable text")
-            await status_message.edit_text(t(update, "no_text"))
+            await _safe_edit_text(status_message,t(update, "no_text"))
             await context.bot.send_message(chat_id, t(update, "help"))
             log_usage(user_id, status="failure", reason="no_text", ocr_pages=ocr_pages,
                       file_type=file_type, file_size_kb=file_size_kb, duration_ms=ocr_ms,
@@ -1634,7 +1650,7 @@ async def _process_file_payload(
 
         if default_lang in VOICE_MAP:
             info = VOICE_MAP[default_lang]
-            await status_message.edit_text(
+            await _safe_edit_text(status_message,
                 t(update, "using_default").format(lang=f'{info["flag"]} {info["name"]}')
             )
             stop_typing.set()
@@ -1648,21 +1664,21 @@ async def _process_file_payload(
                     seg_locs.append(loc)
             label = " + ".join(f'{VOICE_MAP[l]["flag"]} {VOICE_MAP[l]["name"]}'
                                for l in seg_locs if l in VOICE_MAP)
-            await status_message.edit_text(t(update, "detected_lang").format(lang=label))
+            await _safe_edit_text(status_message,t(update, "detected_lang").format(lang=label))
             stop_typing.set()
             await synthesize_and_send(update, context, locale2, status_message=None,
                                       use_segments=True)
         elif (locale2 in VOICE_MAP and conf >= AUTO_DETECT_MIN_CONFIDENCE
                 and coverage >= AUTO_DETECT_MIN_COVERAGE):
             info = VOICE_MAP[locale2]
-            await status_message.edit_text(
+            await _safe_edit_text(status_message,
                 t(update, "detected_lang").format(lang=f'{info["flag"]} {info["name"]}')
             )
             stop_typing.set()
             await synthesize_and_send(update, context, locale2, status_message=None)
         else:
             recent = [c for c in prefs.get("recent", "").split(",") if c]
-            await status_message.edit_text(
+            await _safe_edit_text(status_message,
                 t(update, "choose_language"),
                 reply_markup=build_language_keyboard(update, locale2, recent)
             )
@@ -1670,7 +1686,7 @@ async def _process_file_payload(
         logger.error(f"OCR/handle exception for user {user_id}: {e!r}")
         logger.error(traceback.format_exc())
         try:
-            await status_message.edit_text(t(update, "generic_error"))
+            await _safe_edit_text(status_message,t(update, "generic_error"))
         except Exception:
             await context.bot.send_message(chat_id, t(update, "generic_error"))
         await context.bot.send_message(chat_id, t(update, "help"))
@@ -1908,7 +1924,7 @@ async def synthesize_and_send(update: Update, context: ContextTypes.DEFAULT_TYPE
     try:
         if status_message is not None:
             try:
-                await status_message.edit_text(t(update, "generating_audio").format(lang=lang_label))
+                await _safe_edit_text(status_message,t(update, "generating_audio").format(lang=lang_label))
             except Exception:
                 status_message = None
         if status_message is None:

--- a/app.py
+++ b/app.py
@@ -498,7 +498,7 @@ OCR_FALLBACK = os.environ.get("OCR_FALLBACK", "llm").strip().lower()  # llm | te
 # (Georgian/Armenian). Falls back to Tesseract when these aren't set.
 AZURE_OPENAI_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT", "").strip()
 AZURE_OPENAI_API_KEY = os.environ.get("AZURE_OPENAI_API_KEY", "").strip()
-AZURE_OPENAI_DEPLOYMENT = os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini").strip()
+AZURE_OPENAI_DEPLOYMENT = os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1-mini").strip()
 AZURE_OPENAI_API_VERSION = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-10-21").strip()
 LLM_OCR_MAX_PDF_PAGES = int(os.environ.get("LLM_OCR_MAX_PDF_PAGES", "10"))
 SUPPORT_PAYMENT_MODE = os.environ.get("SUPPORT_PAYMENT_MODE", "admin_stub").strip().lower()  # instant | admin_stub
@@ -1095,7 +1095,7 @@ def _parse_llm_segments(raw):
 
 
 def run_llm_ocr(file_path, file_type, locale2):
-    """OCR via Azure OpenAI vision (gpt-4o-mini): reads scripts Azure Read can't
+    """OCR via Azure OpenAI vision (gpt-4.1-mini): reads scripts Azure Read can't
     (Georgian, Armenian, ...) and returns language-tagged segments so a mixed page
     is read with the right voice per language. Returns (text, raw_segments), or
     ('', None) when Azure OpenAI isn't configured or the call fails."""

--- a/app.py
+++ b/app.py
@@ -1536,24 +1536,32 @@ def extract_text(file_path: str, file_type: str, pinned_lang: str = None) -> Ocr
         for line in page.lines:
             extracted_text += line.content + "\n"
     normalized_text = normalize_ocr_text(extracted_text)
-    if not normalized_text.strip():
-        # Azure read nothing — try the LLM engine, which reads scripts Azure Read
-        # can't (Georgian/Armenian/...). No-op cost when LLM isn't configured.
+    locale2 = None
+    if normalized_text.strip():
+        script_lang = detect_script_language(normalized_text)
+        if script_lang and script_lang in VOICE_MAP:
+            # A distinct script is authoritative — Azure's per-line guess is
+            # unreliable for these (e.g. Georgian was detected as Thai).
+            locale2, conf, coverage = script_lang, 1.0, 1.0
+        else:
+            locale2, conf, coverage = detect_dominant_language(result)
+
+    if not normalized_text.strip() or locale2 not in VOICE_MAP:
+        # Azure Read found nothing, or what it found isn't one of our supported
+        # languages — for scripts it can't read at all (Georgian/Armenian/...) it
+        # doesn't always come back empty, it can mis-recognize the glyphs as
+        # garbage text in some other script (e.g. confidently "Javanese"). Either
+        # way, give the LLM engine a shot before sending the user to the manual
+        # picker. No-op cost when LLM isn't configured.
         if OCR_FALLBACK == "llm" and _azure_openai_configured():
             raw, raw_segments = run_llm_ocr(file_path, file_type, pinned_lang)
             text = normalize_ocr_text(raw or "")
             if text.strip():
                 dominant, segments = _segments_from_raw(raw_segments, pinned_lang or "en")
                 return OcrResult(text, ocr_pages, dominant, 1.0, 1.0, None, True, segments)
-        return OcrResult("", ocr_pages, None, 0.0, 0.0, None, False)
+        if not normalized_text.strip():
+            return OcrResult("", ocr_pages, None, 0.0, 0.0, None, False)
 
-    script_lang = detect_script_language(normalized_text)
-    if script_lang and script_lang in VOICE_MAP:
-        # A distinct script is authoritative — Azure's per-line guess is
-        # unreliable for these (e.g. Georgian was detected as Thai).
-        locale2, conf, coverage = script_lang, 1.0, 1.0
-    else:
-        locale2, conf, coverage = detect_dominant_language(result)
     segments = build_language_segments(result, locale2) if locale2 else None
     return OcrResult(normalized_text, ocr_pages, locale2, conf, coverage,
                      script_lang, False, segments)

--- a/app.py
+++ b/app.py
@@ -493,7 +493,14 @@ AZURE_STORAGE_CONNECTION_STRING = os.environ.get("AZURE_STORAGE_CONNECTION_STRIN
 ADMIN_USER_IDS = {x.strip() for x in os.environ.get("ADMIN_USER_IDS", "").split(",") if x.strip()}
 # User IDs that bypass all daily/bonus limits (e.g. owner, testers). Admins are unlimited too.
 UNLIMITED_USER_IDS = {x.strip() for x in os.environ.get("UNLIMITED_USER_IDS", "").split(",") if x.strip()}
-OCR_FALLBACK = os.environ.get("OCR_FALLBACK", "tesseract").strip().lower()  # tesseract | llm
+OCR_FALLBACK = os.environ.get("OCR_FALLBACK", "llm").strip().lower()  # llm | tesseract
+# Azure OpenAI (vision) for the LLM OCR fallback — reads scripts Azure Read can't
+# (Georgian/Armenian). Falls back to Tesseract when these aren't set.
+AZURE_OPENAI_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT", "").strip()
+AZURE_OPENAI_API_KEY = os.environ.get("AZURE_OPENAI_API_KEY", "").strip()
+AZURE_OPENAI_DEPLOYMENT = os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini").strip()
+AZURE_OPENAI_API_VERSION = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-10-21").strip()
+LLM_OCR_MAX_PDF_PAGES = int(os.environ.get("LLM_OCR_MAX_PDF_PAGES", "10"))
 SUPPORT_PAYMENT_MODE = os.environ.get("SUPPORT_PAYMENT_MODE", "admin_stub").strip().lower()  # instant | admin_stub
 
 
@@ -929,6 +936,64 @@ def detect_script_language(text):
     return None
 
 
+# A secondary language must cover at least this share of the page before we treat
+# it as genuinely multilingual (and read each part with its own voice). Below this,
+# a stray foreign word or a mis-tagged span is folded into the dominant language.
+MULTI_LANG_MIN_SHARE = 0.15
+
+
+def build_language_segments(result, dominant):
+    """Turn Azure's per-span language detection into ordered (locale2, text)
+    segments so a multilingual page (e.g. Russian prose with French quotes) can be
+    read with the right voice per span instead of one voice for everything.
+
+    Returns None for the common monolingual page — the caller then uses the
+    single-voice path unchanged. Only languages with a TTS voice are honored;
+    untagged gaps inherit the surrounding language so a block isn't split by a
+    separator. Every character of result.content is preserved.
+    """
+    content = getattr(result, "content", None) or ""
+    langs = getattr(result, "languages", None) or []
+    n = len(content)
+    if not n or not dominant:
+        return None
+    owner = [None] * n
+    share = defaultdict(int)
+    for lang in langs:
+        loc = ((getattr(lang, "locale", "") or "")[:2]).lower()
+        if loc not in VOICE_MAP:
+            continue
+        for s in (getattr(lang, "spans", None) or []):
+            off = max(0, s.offset or 0)
+            end = min(n, off + (s.length or 0))
+            for i in range(off, end):
+                if owner[i] is None:
+                    owner[i] = loc
+                    share[loc] += 1
+    # Untagged chars (whitespace/punctuation between runs) inherit the preceding
+    # language; a leading gap takes the dominant one.
+    last = dominant
+    for i in range(n):
+        if owner[i] is None:
+            owner[i] = last
+        else:
+            last = owner[i]
+    if len({*owner}) < 2:
+        return None
+    if not any(loc != dominant and share.get(loc, 0) >= MULTI_LANG_MIN_SHARE * n
+               for loc in set(owner)):
+        return None
+    segments = []
+    start = 0
+    for i in range(1, n + 1):
+        if i == n or owner[i] != owner[start]:
+            seg = content[start:i]
+            if seg.strip():
+                segments.append((owner[start], seg))
+            start = i
+    return segments if len(segments) > 1 else None
+
+
 # --- Fallback OCR for languages Azure Read can't extract (e.g. Georgian) ---
 FALLBACK_LANGS = {"ka", "hy"}        # routed to the fallback OCR engine
 TESSERACT_LANG = {"ka": "kat", "hy": "hye"}
@@ -965,17 +1030,138 @@ def run_tesseract_ocr(file_path, file_type, locale2):
     return "\n".join(texts)
 
 
+def _azure_openai_configured():
+    return bool(AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_API_KEY)
+
+
+def _img_mime(data: bytes) -> str:
+    """Sniff an image's MIME type from its magic bytes (for the vision data URL)."""
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    return "image/png"
+
+
+def _pdf_to_png_bytes(file_path, max_pages):
+    """Rasterize a PDF to PNG page images via PyMuPDF (no poppler dependency)."""
+    import fitz  # PyMuPDF
+    zoom = 200 / 72  # ~200 DPI is plenty for OCR
+    mat = fitz.Matrix(zoom, zoom)
+    out = []
+    doc = fitz.open(file_path)
+    try:
+        for page in doc[:max_pages]:
+            out.append(page.get_pixmap(matrix=mat).tobytes("png"))
+    finally:
+        doc.close()
+    return out
+
+
+LLM_OCR_PROMPT = (
+    "You are a precise OCR engine. Transcribe ALL text in the image(s) exactly as "
+    "written. Do not translate, summarize, correct, or add any commentary. "
+    "Preserve the natural reading order; for multi-column layouts read the left "
+    "column top-to-bottom first, then the next column. Group the transcription "
+    "into segments by language. Return ONLY valid JSON of the form "
+    '{"segments":[{"lang":"<ISO 639-1 code>","text":"<verbatim text>"}]}. '
+    "Start a new segment every time the language changes."
+)
+
+
+def _parse_llm_segments(raw):
+    """Parse the model's JSON reply into [(locale2, text)]; tolerant of code fences
+    and surrounding prose. Returns [] if nothing parseable is found."""
+    import json
+    s = (raw or "").strip()
+    i, j = s.find("{"), s.rfind("}")
+    if i == -1 or j == -1 or j < i:
+        return []
+    try:
+        data = json.loads(s[i:j + 1])
+    except Exception:
+        return []
+    segs = []
+    for item in (data.get("segments") or []):
+        loc = str(item.get("lang", "")).strip().lower()[:2]
+        txt = item.get("text", "")
+        if loc and isinstance(txt, str) and txt.strip():
+            segs.append((loc, txt))
+    return segs
+
+
 def run_llm_ocr(file_path, file_type, locale2):
-    # Next prototype step: Azure OpenAI gpt-4o vision.
-    logger.warning("OCR_FALLBACK=llm but LLM OCR is not configured yet.")
-    return ""
+    """OCR via Azure OpenAI vision (gpt-4o-mini): reads scripts Azure Read can't
+    (Georgian, Armenian, ...) and returns language-tagged segments so a mixed page
+    is read with the right voice per language. Returns (text, raw_segments), or
+    ('', None) when Azure OpenAI isn't configured or the call fails."""
+    if not _azure_openai_configured():
+        logger.warning("OCR_FALLBACK=llm but Azure OpenAI is not configured "
+                       "(set AZURE_OPENAI_ENDPOINT / AZURE_OPENAI_API_KEY).")
+        return "", None
+    try:
+        import base64
+        from openai import AzureOpenAI
+        if file_type == "pdf":
+            images = [(png, "image/png") for png in
+                      _pdf_to_png_bytes(file_path, LLM_OCR_MAX_PDF_PAGES)]
+        else:
+            with open(file_path, "rb") as f:
+                data = f.read()
+            images = [(data, _img_mime(data))]
+        content = [{"type": "text", "text": LLM_OCR_PROMPT}]
+        for img, mime in images:
+            b64 = base64.b64encode(img).decode("ascii")
+            content.append({"type": "image_url",
+                            "image_url": {"url": f"data:{mime};base64,{b64}"}})
+        client = AzureOpenAI(azure_endpoint=AZURE_OPENAI_ENDPOINT,
+                             api_key=AZURE_OPENAI_API_KEY,
+                             api_version=AZURE_OPENAI_API_VERSION)
+        resp = client.chat.completions.create(
+            model=AZURE_OPENAI_DEPLOYMENT,
+            messages=[{"role": "user", "content": content}],
+            temperature=0,
+            max_tokens=8000,
+            response_format={"type": "json_object"},
+        )
+        segs = _parse_llm_segments(resp.choices[0].message.content or "")
+        return "\n\n".join(t for _, t in segs), segs
+    except Exception as ex:
+        logger.error(f"LLM OCR failed: {ex!r}")
+        return "", None
+
+
+def _segments_from_raw(raw_segments, fallback_lang):
+    """Normalize LLM raw segments into (dominant_locale2, segments_or_None).
+
+    Drops empty/voiceless spans, normalizes each like the Azure path, picks the
+    language with the most text as dominant, and returns None for `segments` when
+    only one language remains (so the single-voice path is used)."""
+    norm = []
+    for loc, txt in (raw_segments or []):
+        t = normalize_ocr_text(txt or "")
+        if t.strip() and loc in VOICE_MAP:
+            norm.append((loc, t))
+    if not norm:
+        return fallback_lang, None
+    totals = defaultdict(int)
+    for loc, t in norm:
+        totals[loc] += len(t)
+    dominant = max(totals, key=totals.get)
+    segments = norm if len(totals) > 1 else None
+    return dominant, segments
 
 
 def run_fallback_ocr(file_path, file_type, locale2):
-    """Run the configured fallback OCR engine for an Azure-unsupported language."""
-    if OCR_FALLBACK == "llm":
+    """Run the configured fallback OCR engine for an Azure-unsupported language.
+    Returns (text, raw_segments) — raw_segments is None for the Tesseract engine."""
+    if OCR_FALLBACK == "llm" and _azure_openai_configured():
         return run_llm_ocr(file_path, file_type, locale2)
-    return run_tesseract_ocr(file_path, file_type, locale2)
+    return run_tesseract_ocr(file_path, file_type, locale2), None
 
 SUPPORTED_MIME = {
     "image/jpeg", "image/png", "image/tiff", "image/bmp",
@@ -1311,6 +1497,9 @@ class OcrResult(NamedTuple):
     coverage: float             # fraction of text in the dominant language
     script_lang: Optional[str]  # language inferred from a distinct script, if any
     used_fallback: bool         # True when the Tesseract/LLM fallback engine ran
+    # Ordered (locale2, text) spans for a multilingual page, else None. When set,
+    # synthesis reads each span with its own voice instead of one voice for all.
+    segments: Optional[list] = None
 
 
 def extract_text(file_path: str, file_type: str, pinned_lang: str = None) -> OcrResult:
@@ -1322,8 +1511,12 @@ def extract_text(file_path: str, file_type: str, pinned_lang: str = None) -> Ocr
     inferred by script first, then by Azure's per-line detection.
     """
     if pinned_lang in FALLBACK_LANGS:
-        raw = run_fallback_ocr(file_path, file_type, pinned_lang)
-        return OcrResult(normalize_ocr_text(raw or ""), None, None, 0.0, 0.0, None, True)
+        raw, raw_segments = run_fallback_ocr(file_path, file_type, pinned_lang)
+        text = normalize_ocr_text(raw or "")
+        if not text.strip():
+            return OcrResult("", None, None, 0.0, 0.0, None, True)
+        dominant, segments = _segments_from_raw(raw_segments, pinned_lang)
+        return OcrResult(text, None, dominant, 1.0, 1.0, None, True, segments)
 
     # A pinned language on the allowlist is passed to Azure Read as a locale hint,
     # which helps recognition on hard/degraded images. Omitted in the auto-detect
@@ -1342,6 +1535,14 @@ def extract_text(file_path: str, file_type: str, pinned_lang: str = None) -> Ocr
             extracted_text += line.content + "\n"
     normalized_text = normalize_ocr_text(extracted_text)
     if not normalized_text.strip():
+        # Azure read nothing — try the LLM engine, which reads scripts Azure Read
+        # can't (Georgian/Armenian/...). No-op cost when LLM isn't configured.
+        if OCR_FALLBACK == "llm" and _azure_openai_configured():
+            raw, raw_segments = run_llm_ocr(file_path, file_type, pinned_lang)
+            text = normalize_ocr_text(raw or "")
+            if text.strip():
+                dominant, segments = _segments_from_raw(raw_segments, pinned_lang or "en")
+                return OcrResult(text, ocr_pages, dominant, 1.0, 1.0, None, True, segments)
         return OcrResult("", ocr_pages, None, 0.0, 0.0, None, False)
 
     script_lang = detect_script_language(normalized_text)
@@ -1351,7 +1552,9 @@ def extract_text(file_path: str, file_type: str, pinned_lang: str = None) -> Ocr
         locale2, conf, coverage = script_lang, 1.0, 1.0
     else:
         locale2, conf, coverage = detect_dominant_language(result)
-    return OcrResult(normalized_text, ocr_pages, locale2, conf, coverage, script_lang, False)
+    segments = build_language_segments(result, locale2) if locale2 else None
+    return OcrResult(normalized_text, ocr_pages, locale2, conf, coverage,
+                     script_lang, False, segments)
 
 
 async def _process_file_payload(
@@ -1424,6 +1627,7 @@ async def _process_file_payload(
         context.user_data["ocr_job"] = {
             "text": normalized_text, "ocr_pages": ocr_pages, "ocr_ms": ocr_ms,
             "file_type": file_type, "file_size_kb": file_size_kb, "cost_credits": cost_credits,
+            "segments": ocr.segments,
         }
 
         if default_lang in VOICE_MAP:
@@ -1433,6 +1637,19 @@ async def _process_file_payload(
             )
             stop_typing.set()
             await synthesize_and_send(update, context, default_lang, status_message=None)
+        elif ocr.segments:
+            # Genuinely multilingual page: read every part with its own voice
+            # instead of forcing one language (or sending the user to the menu).
+            seg_locs = []
+            for loc, _ in ocr.segments:
+                if loc not in seg_locs:
+                    seg_locs.append(loc)
+            label = " + ".join(f'{VOICE_MAP[l]["flag"]} {VOICE_MAP[l]["name"]}'
+                               for l in seg_locs if l in VOICE_MAP)
+            await status_message.edit_text(t(update, "detected_lang").format(lang=label))
+            stop_typing.set()
+            await synthesize_and_send(update, context, locale2, status_message=None,
+                                      use_segments=True)
         elif (locale2 in VOICE_MAP and conf >= AUTO_DETECT_MIN_CONFIDENCE
                 and coverage >= AUTO_DETECT_MIN_COVERAGE):
             info = VOICE_MAP[locale2]
@@ -1618,18 +1835,30 @@ def _spell_large_numbers(text: str, lang: str) -> str:
     return text
 
 
-def synthesize_to_file(text: str, locale2: str, out_path: str):
+def _voice_ssml_block(seg_text: str, seg_locale: str) -> str:
+    """One <voice> element for a span, with language-specific text cleanup."""
+    info = VOICE_MAP.get(seg_locale) or VOICE_MAP["en"]
+    body = escape_ssml(prepare_tts_text(seg_text, seg_locale))
+    return f'  <voice name="{info["voice"]}">\n    {body}\n  </voice>'
+
+
+def synthesize_to_file(text: str, locale2: str, out_path: str, segments=None):
     """Synthesize `text` to an MP3 at out_path using the voice for locale2
     (English fallback). Returns the Azure SpeechSynthesisResult so callers can
     inspect result.reason / cancellation_details. No Telegram coupling, so it's
-    reusable by the qa toolkit."""
-    info = VOICE_MAP.get(locale2) or VOICE_MAP["en"]
-    body = escape_ssml(prepare_tts_text(text, locale2))
+    reusable by the qa toolkit.
+
+    `segments` (list of (locale2, text)) renders a multilingual page with one
+    voice per span; when None, the whole text is read with the locale2 voice."""
+    dom = VOICE_MAP.get(locale2) or VOICE_MAP["en"]
+    if segments and len(segments) > 1:
+        voices = "\n".join(_voice_ssml_block(seg_text, seg_loc)
+                           for seg_loc, seg_text in segments)
+    else:
+        voices = _voice_ssml_block(text, locale2)
     ssml = f"""
-<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="{info['lang_code']}">
-  <voice name="{info['voice']}">
-    {body}
-  </voice>
+<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="{dom['lang_code']}">
+{voices}
 </speak>
 """
     synthesizer = SpeechSynthesizer(
@@ -1641,9 +1870,13 @@ def synthesize_to_file(text: str, locale2: str, out_path: str):
 
 
 async def synthesize_and_send(update: Update, context: ContextTypes.DEFAULT_TYPE,
-                              locale2: str, status_message=None) -> None:
+                              locale2: str, status_message=None,
+                              use_segments: bool = False) -> None:
     """Synthesize the stored OCR text into a voice message in the chosen language.
-    Shared by the auto-detect path and the manual inline-picker callback."""
+    Shared by the auto-detect path and the manual inline-picker callback.
+
+    use_segments reads a multilingual page with one voice per language span (auto
+    path only); a manually-picked or pinned language always reads in one voice."""
     user_id = update.effective_user.id
     chat_id = update.effective_chat.id
     job = context.user_data.get("ocr_job")
@@ -1682,7 +1915,8 @@ async def synthesize_and_send(update: Update, context: ContextTypes.DEFAULT_TYPE
             )
 
         audio_path = f"{tempfile.mktemp()}.mp3"
-        result = synthesize_to_file(normalized_text, locale2, audio_path)
+        segments = job.get("segments") if use_segments else None
+        result = synthesize_to_file(normalized_text, locale2, audio_path, segments=segments)
 
         if result.reason != ResultReason.SynthesizingAudioCompleted:
             error_message = "Speech synthesis failed."

--- a/qa/run_ocr.py
+++ b/qa/run_ocr.py
@@ -148,6 +148,7 @@ def run(cases, dry_run=False, save_text=False, pin_expected=False):
             "ocr_pages": ocr.ocr_pages,
             "used_fallback": ocr.used_fallback,
             "text_len": len(ocr.text),
+            "seg_langs": [s[0] for s in ocr.segments] if ocr.segments else None,
         })
         exp_lang = case.get("expected_lang")
         row["lang_correct"] = (exp_lang == ocr.locale2) if exp_lang else None
@@ -170,8 +171,9 @@ def run(cases, dry_run=False, save_text=False, pin_expected=False):
 
         mark = "✓" if row.get("lang_correct") in (True, None) else "✗"
         cer_s = f" cer={row['cer']:.3f}" if row.get("cer") is not None else ""
+        seg_s = f" segs={'+'.join(row['seg_langs'])}" if row.get("seg_langs") else ""
         print(f"  {mark} {cid}: lang={ocr.locale2} (exp {exp_lang}) "
-              f"conf={ocr.confidence:.2f} cov={ocr.coverage:.2f}{cer_s}")
+              f"conf={ocr.confidence:.2f} cov={ocr.coverage:.2f}{cer_s}{seg_s}")
         results.append(row)
 
     return results

--- a/qa/test_llm_ocr.py
+++ b/qa/test_llm_ocr.py
@@ -1,0 +1,80 @@
+"""Unit checks for the LLM-OCR parsing/segment helpers (pure, no Azure calls).
+
+The live Azure OpenAI path (run_llm_ocr) needs a provisioned gpt-4o-mini
+deployment and is validated separately via run_ocr.py once configured. Here we
+only exercise the deterministic parsing/segment-building logic.
+
+Run:  python qa/test_llm_ocr.py
+"""
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+os.environ.setdefault("TELEGRAM_API_TOKEN", "qa-dummy-token")
+os.environ.setdefault("BOT_ENV", "qa")
+sys.path.insert(0, str(REPO_ROOT))
+
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+from app import _parse_llm_segments, _segments_from_raw, _img_mime  # noqa: E402
+
+
+def run():
+    failures = []
+
+    def check(name, cond):
+        print(f"  {'✓' if cond else '✗'} {name}")
+        if not cond:
+            failures.append(name)
+
+    # _parse_llm_segments: clean JSON
+    clean = '{"segments":[{"lang":"ka","text":"გამარჯობა"},{"lang":"en","text":"Hello"}]}'
+    p = _parse_llm_segments(clean)
+    check("parses clean json", p == [("ka", "გამარჯობა"), ("en", "Hello")])
+
+    # tolerant of code fences + surrounding prose
+    fenced = "Here you go:\n```json\n" + clean + "\n```\nDone."
+    check("parses fenced json", _parse_llm_segments(fenced) == p)
+
+    # garbage / empty -> []
+    check("garbage -> []", _parse_llm_segments("not json at all") == [])
+    check("empty -> []", _parse_llm_segments("") == [])
+
+    # drops empty/whitespace text and missing lang
+    messy = '{"segments":[{"lang":"ka","text":"  "},{"lang":"","text":"x"},{"lang":"hy","text":"Բարև"}]}'
+    check("drops empty/no-lang spans", _parse_llm_segments(messy) == [("hy", "Բարև")])
+
+    # _segments_from_raw: single known language -> (lang, None)
+    dom, segs = _segments_from_raw([("ka", "გამარჯობა მსოფლიო")], "ka")
+    check("single lang -> no segments", dom == "ka" and segs is None)
+
+    # two known languages -> dominant by text length + segments preserved
+    dom, segs = _segments_from_raw(
+        [("en", "short"), ("ka", "გაცილებით უფრო გრძელი ქართული ტექსტი აქ")], "ka")
+    check("two langs -> dominant ka", dom == "ka")
+    check("two langs -> segments built", segs is not None and len(segs) == 2)
+
+    # voiceless locale dropped; if only that remains -> fallback + None
+    dom, segs = _segments_from_raw([("xx", "unknown script")], "ka")
+    check("voiceless folds to fallback", dom == "ka" and segs is None)
+
+    # _img_mime sniffing
+    check("jpeg magic", _img_mime(b"\xff\xd8\xff\xe0\x00\x10JFIF") == "image/jpeg")
+    check("png magic", _img_mime(b"\x89PNG\r\n\x1a\n....") == "image/png")
+    check("webp magic", _img_mime(b"RIFF\x00\x00\x00\x00WEBPVP8 ") == "image/webp")
+
+    print()
+    if failures:
+        print(f"FAILED: {len(failures)} — {', '.join(failures)}")
+        return 1
+    print("All LLM-OCR helper tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/qa/test_segment.py
+++ b/qa/test_segment.py
@@ -1,0 +1,104 @@
+"""Unit checks for app.build_language_segments and the multi-voice SSML path.
+
+Pure-function tests (no Azure calls): we fake an Azure AnalyzeResult with a
+`content` string and per-language `spans`, the same shape the Read model returns.
+Importing app.py validates env and builds clients, so inject a dummy Telegram
+token first (Azure keys come from .env). Run:  python qa/test_segment.py
+"""
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+os.environ.setdefault("TELEGRAM_API_TOKEN", "qa-dummy-token")
+os.environ.setdefault("BOT_ENV", "qa")
+sys.path.insert(0, str(REPO_ROOT))
+
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+from app import build_language_segments, synthesize_to_file, VOICE_MAP  # noqa: E402
+
+
+class _Span:
+    def __init__(self, offset, length):
+        self.offset = offset
+        self.length = length
+
+
+class _Lang:
+    def __init__(self, locale, spans):
+        self.locale = locale
+        self.spans = [_Span(o, l) for o, l in spans]
+
+
+class _Result:
+    def __init__(self, content, languages):
+        self.content = content
+        self.languages = languages
+
+
+def _ru_fr():
+    ru = "Анна Павловна улыбнулась и обещала заняться Пьером. "  # 51 chars
+    fr = "Eh bien, mon prince, Gênes n'est plus qu'une apanage."   # 53 chars
+    content = ru + fr
+    result = _Result(content, [
+        _Lang("ru", [(0, len(ru))]),
+        _Lang("fr", [(len(ru), len(fr))]),
+    ])
+    return content, ru, fr, result
+
+
+def run():
+    failures = []
+
+    def check(name, cond):
+        mark = "✓" if cond else "✗"
+        print(f"  {mark} {name}")
+        if not cond:
+            failures.append(name)
+
+    # 1. Monolingual page -> None (single-voice path unchanged).
+    text = "The library opened a new reading room this spring."
+    mono = _Result(text, [_Lang("en", [(0, len(text))])])
+    check("monolingual returns None", build_language_segments(mono, "en") is None)
+
+    # 2. Russian + French -> two ordered segments, no text lost.
+    content, ru, fr, result = _ru_fr()
+    segs = build_language_segments(result, "ru")
+    check("ru+fr returns segments", segs is not None and len(segs) == 2)
+    if segs:
+        check("ru+fr order and locales", [s[0] for s in segs] == ["ru", "fr"])
+        check("ru+fr preserves all text", "".join(s[1] for s in segs) == content)
+
+    # 3. Tiny secondary language (< MULTI_LANG_MIN_SHARE) -> folded, None.
+    base = "Это полностью русский текст про городскую библиотеку и читателей. " * 2
+    tiny = base + "OK"
+    res3 = _Result(tiny, [_Lang("ru", [(0, len(base))]), _Lang("en", [(len(base), 2)])])
+    check("tiny secondary stays monolingual", build_language_segments(res3, "ru") is None)
+
+    # 4. Unknown locale (no voice) folded into dominant -> None.
+    res4 = _Result(content, [_Lang("ru", [(0, len(ru))]), _Lang("xx", [(len(ru), len(fr))])])
+    check("unknown locale folds to None", build_language_segments(res4, "ru") is None)
+
+    # 5. Per-span voice blocks use the right (distinct) voice per language.
+    import app as _app
+    blk_ru = _app._voice_ssml_block(ru, "ru")
+    blk_fr = _app._voice_ssml_block(fr, "fr")
+    check("ru voice block uses ru voice", VOICE_MAP["ru"]["voice"] in blk_ru)
+    check("fr voice block uses fr voice", VOICE_MAP["fr"]["voice"] in blk_fr)
+    check("ru/fr voices differ", VOICE_MAP["ru"]["voice"] != VOICE_MAP["fr"]["voice"])
+
+    print()
+    if failures:
+        print(f"FAILED: {len(failures)} — {', '.join(failures)}")
+        return 1
+    print("All segment tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,7 @@ setuptools<81
 opencensus-ext-azure==1.1.9
 anthropic>=0.39,<1.0
 num2words>=0.5,<1.0  # spell out large numbers for natural TTS (e.g. Ukrainian)
+openai>=1.40,<2.0       # Azure OpenAI vision client for the LLM OCR fallback (ka/hy)
+pymupdf>=1.24,<2.0      # PDF -> image rasterization for LLM OCR (replaces poppler)
 
 # System requirement: ffmpeg must be installed and available in PATH


### PR DESCRIPTION
## Summary
- Multi-voice TTS for mixed-language pages (e.g. Russian+French, Georgian+English) — each language span now reads in its own voice instead of collapsing to one.
- LLM-OCR fallback via Azure OpenAI (gpt-4.1-mini) for scripts Azure Document Intelligence can't read (Georgian/Armenian), replacing Tesseract as the default engine.
- Fixed: rescue now also fires when Azure Read mis-recognizes an unsupported script as garbage text in some other language (not just when it returns empty) — was previously sending users straight to the manual picker with no usable OCR.
- Fixed: status-message `edit_text` failures (`BadRequest: Message can't be edited`, seen on cold-start redelivery) no longer abort the whole request — confirmed this hit a real prod user 3x today, OCR succeeded every time but no audio was ever delivered.
- Fixed: Russian mission audio mispronouncing Latin acronyms ("PDF" → "пифдеф").
- Tesseract/poppler stay in the Docker image as a safety net for now — only removed in a follow-up once LLM-OCR is confirmed stable in prod.

Prod env already mirrors dev: `OCR_FALLBACK=llm`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT=gpt-4.1-mini`, and the `azure-openai-api-key` secret are set on `yonchee-bot-prod`.

## Test plan
- [x] `qa/test_segment.py` — 9/9 passing
- [x] `qa/test_llm_ocr.py` — 12/12 passing
- [x] Live-tested on dev: multi-voice TTS (en+ru, es+zh, de+ko, fr+ja), LLM-OCR (Georgian, Armenian), mission audio pronunciation
- [x] Confirm CI deploy succeeds on merge to main
- [x] Resend a Georgian/Armenian doc on prod after deploy to confirm the rescue fix