### PR TITLE
Reliable Georgian/Armenian OCR: rescue every way Azure Read fails on unsupported scripts

### DIFF
--- a/app.py
+++ b/app.py
@@ -905,14 +905,9 @@ def detect_dominant_language(result):
     return best, confidence, coverage
 
 
-def detect_script_language(text):
-    """Infer language from the dominant Unicode script of the OCR text.
-
-    Reliable for scripts that map 1:1 to a language (Georgian, Armenian, Greek,
-    Hebrew, Thai, Devanagari, Hangul, Japanese kana). Returns a 2-letter code,
-    or None for shared scripts (Latin/Cyrillic/Arabic) where the script can't
-    distinguish the language — those defer to Azure's language detection.
-    """
+def _script_shares(text):
+    """Share of alphabetic characters in each distinct-alphabet script (Georgian,
+    Armenian, Greek, ...), keyed by language code. (share, total_letters)."""
     counts = defaultdict(int)
     letters = 0
     for ch in text:
@@ -924,18 +919,46 @@ def detect_script_language(text):
             if any(lo <= o <= hi for lo, hi in ranges):
                 counts[lang] += 1
                 break
-    if letters == 0 or not counts:
-        return None
+    if letters == 0:
+        return {}, 0
     # CJK Han is shared: Japanese if any kana is present, otherwise Chinese.
     if counts.get("han"):
         if counts.get("ja"):
             counts["ja"] += counts.pop("han")
         else:
             counts["zh"] = counts.pop("han")
-    best = max(counts, key=counts.get)
-    if counts[best] / letters >= 0.5:
+    return {lang: cnt / letters for lang, cnt in counts.items()}, letters
+
+
+def detect_script_language(text):
+    """Infer language from the dominant Unicode script of the OCR text.
+
+    Reliable for scripts that map 1:1 to a language (Georgian, Armenian, Greek,
+    Hebrew, Thai, Devanagari, Hangul, Japanese kana). Returns a 2-letter code,
+    or None for shared scripts (Latin/Cyrillic/Arabic) where the script can't
+    distinguish the language — those defer to Azure's language detection.
+    """
+    shares, letters = _script_shares(text)
+    if not shares:
+        return None
+    best = max(shares, key=shares.get)
+    if shares[best] >= 0.5:
         return best
     return None
+
+
+def _has_hidden_distinct_script(text, dominant):
+    """True if a meaningful share of the text is in a distinct-alphabet script
+    (Georgian, Armenian, ...) other than the dominant language — even when it
+    didn't win the 50% majority needed for detect_script_language to override,
+    and even when Azure's per-line language tagger never assigned it a
+    language at all. Untagged spans silently inherit the surrounding
+    language in build_language_segments, which hides exactly this case (e.g. a
+    Georgian+English side-by-side contract where Azure tagged ~97% 'en' and
+    left the Georgian column untagged)."""
+    shares, _ = _script_shares(text)
+    return any(lang != dominant and share >= MULTI_LANG_MIN_SHARE
+               for lang, share in shares.items())
 
 
 _SCRIPT_RANGE_LANGS = {lang for lang, _ in SCRIPT_RANGES} | {"zh"}
@@ -1564,15 +1587,20 @@ def extract_text(file_path: str, file_type: str, pinned_lang: str = None) -> Ocr
     segments = build_language_segments(result, locale2) if locale2 else None
     suspect_segment = segments and any(
         not _segment_script_matches(loc, text) for loc, text in segments)
+    hidden_script = bool(locale2) and _has_hidden_distinct_script(normalized_text, locale2)
 
-    if not normalized_text.strip() or locale2 not in VOICE_MAP or suspect_segment:
+    if not normalized_text.strip() or locale2 not in VOICE_MAP or suspect_segment or hidden_script:
         # Azure Read found nothing, what it found isn't one of our supported
-        # languages, or it tagged a span as a distinct-alphabet language whose
+        # languages, it tagged a span as a distinct-alphabet language whose
         # own script doesn't match (e.g. a Georgian page coming back tagged
-        # Thai+English+Indonesian — the "th" span isn't actually Thai script).
-        # Real multilingual Latin/Cyrillic pairs (kk+ru+en etc.) have no script
-        # to mismatch and are left alone. Either way, give the LLM engine a
-        # shot before trusting this result. No-op cost when LLM isn't configured.
+        # Thai+English+Indonesian — the "th" span isn't actually Thai script),
+        # or a meaningful chunk of the raw text is in a distinct script Azure
+        # never tagged at all (e.g. a Georgian+English side-by-side contract
+        # coming back as 97% "en" — the Georgian column was simply left
+        # untagged and silently inherited the English label). Real
+        # multilingual Latin/Cyrillic pairs (kk+ru+en etc.) have no script to
+        # mismatch and are left alone. Either way, give the LLM engine a shot
+        # before trusting this result. No-op cost when LLM isn't configured.
         if OCR_FALLBACK == "llm" and _azure_openai_configured():
             raw, raw_segments = run_llm_ocr(file_path, file_type, pinned_lang)
             text = normalize_ocr_text(raw or "")

--- a/app.py
+++ b/app.py
@@ -938,6 +938,21 @@ def detect_script_language(text):
     return None
 
 
+_SCRIPT_RANGE_LANGS = {lang for lang, _ in SCRIPT_RANGES} | {"zh"}
+
+
+def _segment_script_matches(locale2, text):
+    """True unless locale2 is a distinct-alphabet language (Georgian, Thai,
+    Korean, ...) whose own script doesn't actually appear in this segment's
+    text — i.e. Azure's per-line tag is provably wrong for its own claimed
+    alphabet. Shared-script languages (Latin/Cyrillic, no SCRIPT_RANGES entry)
+    always pass: there's no independent script signal to check them against,
+    and that's exactly where real multilingual pages (kk+ru+en, etc.) live."""
+    if locale2 not in _SCRIPT_RANGE_LANGS:
+        return True
+    return detect_script_language(text) == locale2
+
+
 # A secondary language must cover at least this share of the page before we treat
 # it as genuinely multilingual (and read each part with its own voice). Below this,
 # a stray foreign word or a mis-tagged span is folded into the dominant language.
@@ -1547,16 +1562,17 @@ def extract_text(file_path: str, file_type: str, pinned_lang: str = None) -> Ocr
             locale2, conf, coverage = detect_dominant_language(result)
 
     segments = build_language_segments(result, locale2) if locale2 else None
-    distinct_langs = len({loc for loc, _ in segments}) if segments else (1 if locale2 else 0)
+    suspect_segment = segments and any(
+        not _segment_script_matches(loc, text) for loc, text in segments)
 
-    if not normalized_text.strip() or locale2 not in VOICE_MAP or distinct_langs >= 3:
-        # Azure Read found nothing, or what it found isn't one of our supported
-        # languages, or it split the page into 3+ "languages" (real multilingual
-        # pages are pairs — ru+fr, ka+en; 3-way splits are the signature of a
-        # script it can't read at all turning into confidently-wrong garbage,
-        # e.g. a Georgian page coming back as Thai+English+Indonesian). Either
-        # way, give the LLM engine a shot before trusting this result. No-op
-        # cost when LLM isn't configured.
+    if not normalized_text.strip() or locale2 not in VOICE_MAP or suspect_segment:
+        # Azure Read found nothing, what it found isn't one of our supported
+        # languages, or it tagged a span as a distinct-alphabet language whose
+        # own script doesn't match (e.g. a Georgian page coming back tagged
+        # Thai+English+Indonesian — the "th" span isn't actually Thai script).
+        # Real multilingual Latin/Cyrillic pairs (kk+ru+en etc.) have no script
+        # to mismatch and are left alone. Either way, give the LLM engine a
+        # shot before trusting this result. No-op cost when LLM isn't configured.
         if OCR_FALLBACK == "llm" and _azure_openai_configured():
             raw, raw_segments = run_llm_ocr(file_path, file_type, pinned_lang)
             text = normalize_ocr_text(raw or "")

--- a/app.py
+++ b/app.py
@@ -1102,6 +1102,85 @@ def _pdf_to_png_bytes(file_path, max_pages):
     return out
 
 
+# --- Detecting text Azure Read silently dropped (unreadable scripts) ---
+# Azure prebuilt-read omits text in scripts it can't read (Georgian/Armenian)
+# with NO trace in the result when the page also has a readable language — a
+# bilingual Georgian+English contract comes back as clean, confident English.
+# The only signal is in the pixels: ink the OCR never covered with a word box.
+INK_DARK_THRESHOLD = 140        # grayscale value below which a pixel counts as ink
+UNREAD_INK_MIN_FRACTION = 0.30  # share of ink left unrecognized that means dropped text
+_INK_SCAN_MAX_DIM = 1600        # downscale longest side before scanning (scale-invariant)
+_INK_MASK_DILATE = 7            # grow recognized boxes a few px to absorb anti-aliasing
+_INK_SCAN_DPI = 150             # PDF rasterization DPI for the scan
+
+
+def _ink_scan_eligible(file_type, ocr_pages):
+    """Only scan images and PDFs small enough that the LLM could rescue them
+    anyway — a huge PDF is almost always digital text Azure read in full."""
+    if file_type != "pdf":
+        return True
+    return bool(ocr_pages) and ocr_pages <= LLM_OCR_MAX_PDF_PAGES
+
+
+def _ink_scan_pages(file_path, file_type):
+    """Yield (grayscale PIL image, page_index) for each page to scan."""
+    from PIL import Image
+    if file_type == "pdf":
+        import fitz
+        doc = fitz.open(file_path)
+        try:
+            for i in range(doc.page_count):
+                pm = doc.load_page(i).get_pixmap(dpi=_INK_SCAN_DPI)
+                img = Image.frombytes(
+                    "RGB" if pm.n >= 3 else "L", (pm.width, pm.height), pm.samples)
+                yield img.convert("L"), i
+        finally:
+            doc.close()
+    else:
+        yield Image.open(file_path).convert("L"), 0
+
+
+def _unread_ink_fraction(file_path, file_type, result):
+    """Fraction of dark, text-like pixels that fall outside every word box Azure
+    Read recognized — across pages, the worst page wins. High only when Azure
+    silently dropped a chunk of the page (a script it can't read). Returns 0.0 on
+    any error so a scan failure can never break the OCR flow."""
+    try:
+        from PIL import Image, ImageDraw, ImageFilter, ImageChops
+        pages = list(result.pages or [])
+        worst = 0.0
+        for img, idx in _ink_scan_pages(file_path, file_type):
+            if idx >= len(pages):
+                break
+            page = pages[idx]
+            scale = min(1.0, _INK_SCAN_MAX_DIM / max(img.size))
+            if scale < 1.0:
+                img = img.resize((max(1, int(img.size[0] * scale)),
+                                  max(1, int(img.size[1] * scale))))
+            W, H = img.size
+            sx = W / (page.width or W)
+            sy = H / (page.height or H)
+            ink = img.point(lambda p: 255 if p < INK_DARK_THRESHOLD else 0, mode="L")
+            total_ink = ink.histogram()[255]
+            if not total_ink:
+                continue
+            mask = Image.new("L", (W, H), 0)
+            draw = ImageDraw.Draw(mask)
+            for w in (getattr(page, "words", None) or []):
+                poly = w.polygon or []
+                if len(poly) < 6:
+                    continue
+                draw.polygon([(poly[i] * sx, poly[i + 1] * sy)
+                              for i in range(0, len(poly), 2)], fill=255)
+            mask = mask.filter(ImageFilter.MaxFilter(_INK_MASK_DILATE))
+            inside_ink = ImageChops.multiply(ink, mask).histogram()[255]
+            worst = max(worst, (total_ink - inside_ink) / total_ink)
+        return worst
+    except Exception as ex:
+        logger.warning(f"unread-ink scan failed: {ex!r}")
+        return 0.0
+
+
 LLM_OCR_PROMPT = (
     "You are a precise OCR engine. Transcribe ALL text in the image(s) exactly as "
     "written. Do not translate, summarize, correct, or add any commentary. "
@@ -1589,18 +1668,28 @@ def extract_text(file_path: str, file_type: str, pinned_lang: str = None) -> Ocr
         not _segment_script_matches(loc, text) for loc, text in segments)
     hidden_script = bool(locale2) and _has_hidden_distinct_script(normalized_text, locale2)
 
-    if not normalized_text.strip() or locale2 not in VOICE_MAP or suspect_segment or hidden_script:
-        # Azure Read found nothing, what it found isn't one of our supported
-        # languages, it tagged a span as a distinct-alphabet language whose
-        # own script doesn't match (e.g. a Georgian page coming back tagged
-        # Thai+English+Indonesian — the "th" span isn't actually Thai script),
-        # or a meaningful chunk of the raw text is in a distinct script Azure
-        # never tagged at all (e.g. a Georgian+English side-by-side contract
-        # coming back as 97% "en" — the Georgian column was simply left
-        # untagged and silently inherited the English label). Real
-        # multilingual Latin/Cyrillic pairs (kk+ru+en etc.) have no script to
-        # mismatch and are left alone. Either way, give the LLM engine a shot
-        # before trusting this result. No-op cost when LLM isn't configured.
+    # Reasons to distrust Azure's result and try the LLM engine:
+    #  - it found nothing, or what it found isn't a language we have a voice for;
+    #  - it tagged a span as a distinct-alphabet language whose own script isn't
+    #    actually there (a Georgian page coming back tagged Thai+English+Indo);
+    #  - a chunk of the extracted text is in a distinct script it never tagged.
+    # Real multilingual Latin/Cyrillic pairs (kk+ru+en etc.) have no script to
+    # mismatch and are left alone.
+    needs_rescue = (not normalized_text.strip() or locale2 not in VOICE_MAP
+                    or suspect_segment or hidden_script)
+
+    # Last resort, and the only signal for the worst case: Azure can silently
+    # DROP text in a script it can't read when the page also has a readable
+    # language, leaving NO trace in the result (a Georgian+English contract
+    # comes back as clean, confident English with the Georgian column simply
+    # gone). Catch it by scanning the image for text-like ink Azure never
+    # covered with a word box. Only worth the pixels when the LLM can rescue.
+    if (not needs_rescue and OCR_FALLBACK == "llm" and _azure_openai_configured()
+            and _ink_scan_eligible(file_type, ocr_pages)
+            and _unread_ink_fraction(file_path, file_type, result) >= UNREAD_INK_MIN_FRACTION):
+        needs_rescue = True
+
+    if needs_rescue:
         if OCR_FALLBACK == "llm" and _azure_openai_configured():
             raw, raw_segments = run_llm_ocr(file_path, file_type, pinned_lang)
             text = normalize_ocr_text(raw or "")

--- a/app.py
+++ b/app.py
@@ -1546,23 +1546,26 @@ def extract_text(file_path: str, file_type: str, pinned_lang: str = None) -> Ocr
         else:
             locale2, conf, coverage = detect_dominant_language(result)
 
-    if not normalized_text.strip() or locale2 not in VOICE_MAP:
+    segments = build_language_segments(result, locale2) if locale2 else None
+    distinct_langs = len({loc for loc, _ in segments}) if segments else (1 if locale2 else 0)
+
+    if not normalized_text.strip() or locale2 not in VOICE_MAP or distinct_langs >= 3:
         # Azure Read found nothing, or what it found isn't one of our supported
-        # languages — for scripts it can't read at all (Georgian/Armenian/...) it
-        # doesn't always come back empty, it can mis-recognize the glyphs as
-        # garbage text in some other script (e.g. confidently "Javanese"). Either
-        # way, give the LLM engine a shot before sending the user to the manual
-        # picker. No-op cost when LLM isn't configured.
+        # languages, or it split the page into 3+ "languages" (real multilingual
+        # pages are pairs — ru+fr, ka+en; 3-way splits are the signature of a
+        # script it can't read at all turning into confidently-wrong garbage,
+        # e.g. a Georgian page coming back as Thai+English+Indonesian). Either
+        # way, give the LLM engine a shot before trusting this result. No-op
+        # cost when LLM isn't configured.
         if OCR_FALLBACK == "llm" and _azure_openai_configured():
             raw, raw_segments = run_llm_ocr(file_path, file_type, pinned_lang)
             text = normalize_ocr_text(raw or "")
             if text.strip():
-                dominant, segments = _segments_from_raw(raw_segments, pinned_lang or "en")
-                return OcrResult(text, ocr_pages, dominant, 1.0, 1.0, None, True, segments)
+                dominant, rescued_segments = _segments_from_raw(raw_segments, pinned_lang or "en")
+                return OcrResult(text, ocr_pages, dominant, 1.0, 1.0, None, True, rescued_segments)
         if not normalized_text.strip():
             return OcrResult("", ocr_pages, None, 0.0, 0.0, None, False)
 
-    segments = build_language_segments(result, locale2) if locale2 else None
     return OcrResult(normalized_text, ocr_pages, locale2, conf, coverage,
                      script_lang, False, segments)
 

--- a/qa/test_extract_rescue.py
+++ b/qa/test_extract_rescue.py
@@ -1,0 +1,133 @@
+"""Regression test for the 3-way-language-split rescue trigger in extract_text.
+
+Reproduces a real prod failure: a Georgian page that Azure Read can't actually
+read came back split into three *supported* languages (Thai/English/
+Indonesian) with high confidence — none of them Georgian — because Azure's
+per-line classifier guessed wrong on every line. The old rescue only fired on
+empty text or an unsupported dominant locale, so this page sailed through and
+got rendered with three wrong voices instead of running the LLM-OCR rescue.
+
+Mocks doc_client.begin_analyze_document and run_llm_ocr (no live Azure calls).
+Run:  python qa/test_extract_rescue.py
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+os.environ.setdefault("TELEGRAM_API_TOKEN", "qa-dummy-token")
+os.environ.setdefault("BOT_ENV", "qa")
+sys.path.insert(0, str(REPO_ROOT))
+
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+import app  # noqa: E402
+
+
+class _Span:
+    def __init__(self, offset, length):
+        self.offset = offset
+        self.length = length
+
+
+class _Lang:
+    def __init__(self, locale, confidence, spans):
+        self.locale = locale
+        self.confidence = confidence
+        self.spans = [_Span(o, l) for o, l in spans]
+
+
+class _Line:
+    def __init__(self, content):
+        self.content = content
+
+
+class _Page:
+    def __init__(self, content):
+        self.lines = [_Line(content)]
+
+
+class _Result:
+    def __init__(self, content, languages):
+        self.content = content
+        self.languages = languages
+        self.pages = [_Page(content)]
+
+
+class _Poller:
+    def __init__(self, result):
+        self._result = result
+
+    def result(self):
+        return self._result
+
+
+def run():
+    failures = []
+
+    def check(name, cond):
+        print(f"  {'✓' if cond else '✗'} {name}")
+        if not cond:
+            failures.append(name)
+
+    fake_path = tempfile.mktemp()
+    Path(fake_path).write_bytes(b"\x00")
+
+    # A garbage-but-plausible 3-way split: Azure tags three equal-length runs
+    # as th/en/id, none of them Georgian — detect_script_language finds no
+    # dominant script (plain Latin-range filler), so it can't override.
+    seg_th, seg_en, seg_id = "T" * 10, "E" * 10, "I" * 10
+    content = seg_th + seg_en + seg_id
+    bad_result = _Result(content, [
+        _Lang("th-TH", 0.91, [(0, 10)]),
+        _Lang("en-US", 0.85, [(10, 10)]),
+        _Lang("id-ID", 0.80, [(20, 10)]),
+    ])
+
+    rescued_text = "ნამდვილი ქართული ტექსტი"
+
+    with patch.object(app.doc_client, "begin_analyze_document",
+                       return_value=_Poller(bad_result)), \
+         patch.object(app, "run_llm_ocr",
+                       return_value=(rescued_text, [("ka", rescued_text)])), \
+         patch.object(app, "OCR_FALLBACK", "llm"), \
+         patch.object(app, "_azure_openai_configured", return_value=True):
+        result = app.extract_text(fake_path, "image")
+
+    check("3-way split triggers the LLM rescue", result.text.startswith(rescued_text))
+    check("rescued result is tagged ka", result.locale2 == "ka")
+    check("rescued result marked used_fallback", result.used_fallback is True)
+
+    # Sanity: a genuine 2-language page (ru+fr) must NOT be rescued away —
+    # the >=3 trigger must not catch ordinary multilingual pages.
+    ru, fr = "Р" * 30, "F" * 10
+    good_result = _Result(ru + fr, [
+        _Lang("ru-RU", 0.99, [(0, 30)]),
+        _Lang("fr-FR", 0.95, [(30, 10)]),
+    ])
+    with patch.object(app.doc_client, "begin_analyze_document",
+                       return_value=_Poller(good_result)), \
+         patch.object(app, "run_llm_ocr", side_effect=AssertionError("should not be called")), \
+         patch.object(app, "OCR_FALLBACK", "llm"), \
+         patch.object(app, "_azure_openai_configured", return_value=True):
+        result2 = app.extract_text(fake_path, "image")
+
+    check("2-language page is not rescued", result2.locale2 == "ru" and result2.segments is not None)
+
+    os.remove(fake_path)
+    print()
+    if failures:
+        print(f"FAILED: {len(failures)} — {', '.join(failures)}")
+        return 1
+    print("All extract_text rescue tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/qa/test_extract_rescue.py
+++ b/qa/test_extract_rescue.py
@@ -120,6 +120,27 @@ def run():
 
     check("2-language page is not rescued", result2.locale2 == "ru" and result2.segments is not None)
 
+    # A genuine 3-language Latin/Cyrillic page (kk+ru+en — Yonchee's actual
+    # target market, e.g. a Kazakh document quoting Russian and English) must
+    # NOT be rescued either: none of these have a distinct-script signal to
+    # mismatch, so the suspect-segment check must leave them alone. Rescuing
+    # these anyway would mean paying for an LLM-OCR call on routine traffic.
+    kk, ru3, en3 = "Қ" * 20, "Р" * 20, "E" * 20
+    trilingual_result = _Result(kk + ru3 + en3, [
+        _Lang("kk-KZ", 0.98, [(0, 20)]),
+        _Lang("ru-RU", 0.97, [(20, 20)]),
+        _Lang("en-US", 0.96, [(40, 20)]),
+    ])
+    with patch.object(app.doc_client, "begin_analyze_document",
+                       return_value=_Poller(trilingual_result)), \
+         patch.object(app, "run_llm_ocr", side_effect=AssertionError("should not be called")), \
+         patch.object(app, "OCR_FALLBACK", "llm"), \
+         patch.object(app, "_azure_openai_configured", return_value=True):
+        result3 = app.extract_text(fake_path, "image")
+
+    check("genuine 3-language kk+ru+en page is not rescued",
+          result3.segments is not None and len({loc for loc, _ in result3.segments}) == 3)
+
     os.remove(fake_path)
     print()
     if failures:

--- a/qa/test_extract_rescue.py
+++ b/qa/test_extract_rescue.py
@@ -114,6 +114,7 @@ def run():
     with patch.object(app.doc_client, "begin_analyze_document",
                        return_value=_Poller(good_result)), \
          patch.object(app, "run_llm_ocr", side_effect=AssertionError("should not be called")), \
+         patch.object(app, "_unread_ink_fraction", return_value=0.0), \
          patch.object(app, "OCR_FALLBACK", "llm"), \
          patch.object(app, "_azure_openai_configured", return_value=True):
         result2 = app.extract_text(fake_path, "image")
@@ -134,6 +135,7 @@ def run():
     with patch.object(app.doc_client, "begin_analyze_document",
                        return_value=_Poller(trilingual_result)), \
          patch.object(app, "run_llm_ocr", side_effect=AssertionError("should not be called")), \
+         patch.object(app, "_unread_ink_fraction", return_value=0.0), \
          patch.object(app, "OCR_FALLBACK", "llm"), \
          patch.object(app, "_azure_openai_configured", return_value=True):
         result3 = app.extract_text(fake_path, "image")
@@ -161,6 +163,38 @@ def run():
 
     check("untagged Georgian column triggers the LLM rescue",
           result4.used_fallback is True and result4.text.startswith(rescued_text))
+
+    # The real-world worst case (verified on en-ge1.png): Azure drops the
+    # Georgian column ENTIRELY — not even garbage, no Georgian unicode in the
+    # text at all — and returns clean, confident English. Nothing in the result
+    # can reveal it; only the image pixels can. Here the text is pure Latin
+    # English (no hidden script to catch) and the only signal is a high
+    # unread-ink fraction.
+    clean_en = _Result("E" * 60, [_Lang("en-US", 0.98, [(0, 60)])])
+    with patch.object(app.doc_client, "begin_analyze_document",
+                       return_value=_Poller(clean_en)), \
+         patch.object(app, "_unread_ink_fraction", return_value=0.52), \
+         patch.object(app, "run_llm_ocr",
+                       return_value=(rescued_text, [("ka", rescued_text), ("en", "english half")])), \
+         patch.object(app, "OCR_FALLBACK", "llm"), \
+         patch.object(app, "_azure_openai_configured", return_value=True):
+        result5 = app.extract_text(fake_path, "image")
+
+    check("dropped column (high unread ink) triggers the LLM rescue",
+          result5.used_fallback is True and result5.text.startswith(rescued_text))
+
+    # And the same clean English page with LOW unread ink (genuinely monolingual)
+    # must NOT pay for an LLM call.
+    with patch.object(app.doc_client, "begin_analyze_document",
+                       return_value=_Poller(clean_en)), \
+         patch.object(app, "_unread_ink_fraction", return_value=0.02), \
+         patch.object(app, "run_llm_ocr", side_effect=AssertionError("should not be called")), \
+         patch.object(app, "OCR_FALLBACK", "llm"), \
+         patch.object(app, "_azure_openai_configured", return_value=True):
+        result6 = app.extract_text(fake_path, "image")
+
+    check("clean English page with low unread ink is not rescued",
+          result6.locale2 == "en" and result6.used_fallback is False)
 
     os.remove(fake_path)
     print()

--- a/qa/test_extract_rescue.py
+++ b/qa/test_extract_rescue.py
@@ -141,6 +141,27 @@ def run():
     check("genuine 3-language kk+ru+en page is not rescued",
           result3.segments is not None and len({loc for loc, _ in result3.segments}) == 3)
 
+    # The original motivating bug: a side-by-side Georgian+English contract.
+    # Azure tags only the English column and leaves the Georgian column
+    # completely untagged (no language span at all, not even a wrong one) —
+    # build_language_segments has nothing to split on, so it silently
+    # inherits "en" everywhere and reports a clean monolingual English page.
+    ka_text = "ა" * 20
+    en_text = "E" * 40
+    bilingual_result = _Result(ka_text + en_text, [
+        _Lang("en-US", 0.98, [(len(ka_text), len(en_text))]),
+    ])
+    with patch.object(app.doc_client, "begin_analyze_document",
+                       return_value=_Poller(bilingual_result)), \
+         patch.object(app, "run_llm_ocr",
+                       return_value=(rescued_text, [("ka", rescued_text), ("en", "the english half")])), \
+         patch.object(app, "OCR_FALLBACK", "llm"), \
+         patch.object(app, "_azure_openai_configured", return_value=True):
+        result4 = app.extract_text(fake_path, "image")
+
+    check("untagged Georgian column triggers the LLM rescue",
+          result4.used_fallback is True and result4.text.startswith(rescued_text))
+
     os.remove(fake_path)
     print()
     if failures:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ anthropic>=0.39,<1.0
 num2words>=0.5,<1.0  # spell out large numbers for natural TTS (e.g. Ukrainian)
 openai>=1.40,<2.0       # Azure OpenAI vision client for the LLM OCR fallback (ka/hy)
 pymupdf>=1.24,<2.0      # PDF -> image rasterization for LLM OCR (replaces poppler)
+pillow>=10.0,<13        # image ink-coverage scan: detect text Azure Read silently dropped
 
 # System requirement: ffmpeg must be installed and available in PATH


### PR DESCRIPTION
## Summary
Follow-up to #10. The multilingual OCR shipped, but real prod traffic exposed four distinct ways Azure Document Intelligence `prebuilt-read` fails on Georgian/Armenian (scripts it cannot read), each previously slipping past the LLM-OCR rescue and either erroring, sending the user to the manual picker, or silently reading only half the page. All four are now caught.

### The four failure modes (all confirmed from prod logs / real Azure calls)
1. **Mis-tagged as one wrong language** — a Georgian photo comes back as `lang=jv` (Javanese) at conf 0.51. Rescue now fires whenever the detected locale isn't a language we have a voice for, not just on empty text. (`89065a5`)
2. **Garbage split across several *supported* languages** — a Georgian page tagged Thai+English+Indonesian at once, slipping past the "unsupported locale" check. Now flagged precisely: a segment whose claimed distinct-alphabet language (ka/hy/ko/th/...) doesn't actually contain that script is suspect — without touching genuine Latin/Cyrillic multilingual pages. (`c7647e8`)
3. **A distinct script present but left untagged** — Azure tags ~97% "en" and leaves a Georgian span with no language at all, which then silently inherits "en". Now caught by scanning the extracted text's own script shares. (`f859721`)
4. **A whole column silently dropped** — the worst case (the original motivating example, a side-by-side Georgian+English contract): Azure returns clean, confident English with the Georgian column **entirely absent** from the result — no garbage, no untagged span, nothing. The only signal is in the pixels. After Azure Read we now render the page, mask every recognized word box, and rescue when >30% of the dark text-like ink was never recognized. Measured separation is wide: dropped-column page 0.52 vs clean docs 0.00. Scan runs only when the LLM can rescue and the cheap checks didn't already fire, so clean documents cost nothing. (`c1bf53d`)

Adds Pillow (for the ink scan). Tesseract/poppler still in the image as a safety net until LLM-OCR is proven in prod.

## Validated on dev (live)
- 🇬🇪 Georgian + 🇬🇧 English contract → reads both columns
- 🇰🇿 Kazakh + 🇷🇺 Russian + 🇬🇧 English page → three voices, NOT mis-rescued
- Pure Georgian / Armenian → correct extraction
- Clean English / Russian / Ukrainian → unchanged, no LLM spend

## Test plan
- [x] `qa/test_extract_rescue.py` — 8 cases (all four rescue triggers + negative cases for genuine 2- and 3-language Latin/Cyrillic pages)
- [x] `qa/test_segment.py`, `qa/test_llm_ocr.py`, `qa/test_normalize.py`
- [x] Real Azure calls on the template corpus confirm the ink-fraction separation
- [x] CI deploy to prod succeeds
- [x] Re-send the Georgian+English contract on prod to confirm

## Known follow-ups (not blocking)
- Reading order on complex multi-column/table layouts is approximate.
- Step 4: remove tesseract/poppler from the Dockerfile once prod LLM-OCR is confirmed.
- Budget alert on Azure OpenAI spend.