### PR TITLE
chore: drop tesseract/poppler — LLM-OCR is the only fallback engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# System deps: ffmpeg (audio), tesseract + Georgian/Armenian data and poppler
-# (fallback OCR for scripts Azure Read can't extract).
+# System deps: ffmpeg for audio encoding. OCR for scripts Azure Read can't
+# extract (Georgian/Armenian) now goes through Azure OpenAI vision, and PDFs
+# are rasterized in-process via PyMuPDF — no tesseract/poppler needed.
 RUN apt-get update && apt-get install -y \
         ffmpeg \
-        tesseract-ocr tesseract-ocr-kat tesseract-ocr-hye \
-        poppler-utils \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/app.py
+++ b/app.py
@@ -495,9 +495,10 @@ AZURE_STORAGE_CONNECTION_STRING = os.environ.get("AZURE_STORAGE_CONNECTION_STRIN
 ADMIN_USER_IDS = {x.strip() for x in os.environ.get("ADMIN_USER_IDS", "").split(",") if x.strip()}
 # User IDs that bypass all daily/bonus limits (e.g. owner, testers). Admins are unlimited too.
 UNLIMITED_USER_IDS = {x.strip() for x in os.environ.get("UNLIMITED_USER_IDS", "").split(",") if x.strip()}
-OCR_FALLBACK = os.environ.get("OCR_FALLBACK", "llm").strip().lower()  # llm | tesseract
+OCR_FALLBACK = os.environ.get("OCR_FALLBACK", "llm").strip().lower()  # llm (default) | off
 # Azure OpenAI (vision) for the LLM OCR fallback — reads scripts Azure Read can't
-# (Georgian/Armenian). Falls back to Tesseract when these aren't set.
+# (Georgian/Armenian). When these aren't set the fallback yields no text (those
+# languages simply can't be read); there is no on-box OCR engine anymore.
 AZURE_OPENAI_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT", "").strip()
 AZURE_OPENAI_API_KEY = os.environ.get("AZURE_OPENAI_API_KEY", "").strip()
 AZURE_OPENAI_DEPLOYMENT = os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1-mini").strip()
@@ -1036,38 +1037,6 @@ def build_language_segments(result, dominant):
 
 # --- Fallback OCR for languages Azure Read can't extract (e.g. Georgian) ---
 FALLBACK_LANGS = {"ka", "hy"}        # routed to the fallback OCR engine
-TESSERACT_LANG = {"ka": "kat", "hy": "hye"}
-
-
-def run_tesseract_ocr(file_path, file_type, locale2):
-    """OCR via local Tesseract (Georgian/Armenian language data in the image)."""
-    import subprocess
-    import glob
-    lang = TESSERACT_LANG.get(locale2, "eng")
-    images = [file_path]
-    tmp_imgs = []
-    if file_type == "pdf":
-        prefix = tempfile.mktemp()
-        r = subprocess.run(["pdftoppm", "-r", "300", "-png", file_path, prefix],
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if r.returncode != 0:
-            logger.error(f"pdftoppm error: {r.stderr.decode(errors='ignore')[:200]}")
-            raise RuntimeError("PDF rasterization failed")
-        tmp_imgs = sorted(glob.glob(prefix + "*.png"))
-        images = tmp_imgs or [file_path]
-    texts = []
-    try:
-        for img in images:
-            r = subprocess.run(["tesseract", img, "stdout", "-l", lang],
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            if r.returncode != 0:
-                logger.warning(f"tesseract error: {r.stderr.decode(errors='ignore')[:200]}")
-                continue
-            texts.append(r.stdout.decode("utf-8", errors="ignore"))
-    finally:
-        for p in tmp_imgs:
-            remove_temp_file(p)
-    return "\n".join(texts)
 
 
 def _azure_openai_configured():
@@ -1276,11 +1245,12 @@ def _segments_from_raw(raw_segments, fallback_lang):
 
 
 def run_fallback_ocr(file_path, file_type, locale2):
-    """Run the configured fallback OCR engine for an Azure-unsupported language.
-    Returns (text, raw_segments) — raw_segments is None for the Tesseract engine."""
+    """Run the LLM OCR engine for an Azure-unsupported language (Georgian/
+    Armenian). Returns (text, raw_segments), or ('', None) when the LLM isn't
+    configured — the caller then reports no text for that language."""
     if OCR_FALLBACK == "llm" and _azure_openai_configured():
         return run_llm_ocr(file_path, file_type, locale2)
-    return run_tesseract_ocr(file_path, file_type, locale2), None
+    return "", None
 
 SUPPORTED_MIME = {
     "image/jpeg", "image/png", "image/tiff", "image/bmp",
@@ -1615,7 +1585,7 @@ class OcrResult(NamedTuple):
     confidence: float           # detection confidence (text-length-weighted)
     coverage: float             # fraction of text in the dominant language
     script_lang: Optional[str]  # language inferred from a distinct script, if any
-    used_fallback: bool         # True when the Tesseract/LLM fallback engine ran
+    used_fallback: bool         # True when the LLM fallback engine ran
     # Ordered (locale2, text) spans for a multilingual page, else None. When set,
     # synthesis reads each span with its own voice instead of one voice for all.
     segments: Optional[list] = None

--- a/qa/generate_corpus.py
+++ b/qa/generate_corpus.py
@@ -345,8 +345,8 @@ def main():
         write_case(cases, f"gen-mixed-{a}-{b}", img, text, None, f"mixed {a}+{b}")
 
 # Number-heavy cases (clean + one mild-degraded) for the Azure-OCR languages.
-    # Georgian (ka) is omitted here — it goes through the Tesseract fallback, which
-    # isn't available locally; use run_tts.py --numbers to hear the ka voice.
+    # Georgian (ka) is omitted here — it goes through the Azure OpenAI LLM-OCR
+    # fallback, which needs cloud config; use run_tts.py --numbers to hear the ka voice.
     for lang in ["en", "ru", "uk"]:
         text = NUMBER_TEXTS[lang]
         font = get_font(font_paths(lang)[0], 34)


### PR DESCRIPTION
## Summary
Step 4 of the multilingual OCR work (follow-up to #10/#11). LLM-OCR (Azure OpenAI vision) is confirmed handling Georgian/Armenian in prod, so the on-box Tesseract engine and its poppler PDF rasterizer are no longer used.

- Removed `tesseract-ocr*` + `poppler-utils` from the Docker image (ffmpeg stays).
- Deleted the now-dead `run_tesseract_ocr` / `TESSERACT_LANG` code so a stray call can't crash on a missing binary.
- `run_fallback_ocr` is now LLM-only — returns `('', None)` when the LLM isn't configured (those languages then report no text; there is no on-box fallback anymore).
- `OCR_FALLBACK` is now `llm` (default) | `off`.
- PDFs continue to rasterize in-process via PyMuPDF.

## Test plan
- [x] `import app` clean; no residual tesseract/poppler refs in code
- [x] `qa/test_segment.py`, `qa/test_llm_ocr.py`, `qa/test_extract_rescue.py`, `qa/test_normalize.py` all pass
- [x] Image rebuilt without tesseract/poppler and deployed+started on dev
- [x] Georgian/Armenian confirmed still readable on dev (LLM-OCR does the work)
- [x] CI deploy to prod succeeds

## Note
Budget alert tail is already done out-of-band: dedicated `yonchee-openai-5usd` Azure budget ($5/mo, filtered to the OpenAI resource, alerts 50/80/100%).